### PR TITLE
Allow another task to set file to save next job to

### DIFF
--- a/build/!PrintPDF/!Run,feb
+++ b/build/!PrintPDF/!Run,feb
@@ -23,7 +23,7 @@
 | permissions and limitations under the Licence.
 
 Set PrintPDF$Help <Obey$Dir>.!Help
-Set PrintPDF$Version "0.10"
+Set PrintPDF$Version "0.11"
 Set PrintPDF$Web "http://www.stevefryatt.org.uk/software/printpdf/"
 Set PrintPDF$Title "PrintPDF"
 Set PrintPDF$Publisher "Stephen Fryatt"


### PR DESCRIPTION
Here's my preliminary implementation of the change we discussed. I've defined a message which is from a Sine Nomine Software allocation. We ought to change to a message number belonging to you, really.

The format of the message only allows an application to set the file to save to. You may want to redesign it a bit so that other options can be set via the message, such as the PDF version etc. I was just keeping it simple.

I'll send you a test version of ImpEmail shortly.

Apologies about the changes to whitespace. The editor I was using must behave differently from yours. I tried to copy your style and use tabs, but it may not be totally right.